### PR TITLE
updated variable scope, altered how we get sounds

### DIFF
--- a/code.py
+++ b/code.py
@@ -8,64 +8,85 @@ from adafruit_itertools import chain
 from audiomp3 import MP3Decoder
 import microcontroller
 
-audio = audiobusio.I2SOut(board.GP10, board.GP11, board.GP9) #BCLK_PIN, WS_PIN, SDIN_PIN
 server = HTTPServer(socketpool.SocketPool(wifi.radio))
+# IO setup
 board_led = digitalio.DigitalInOut(board.LED)
 board_led.direction = digitalio.Direction.OUTPUT
+lamp = pwmio.PWMOut(board.GP17)
 
-TARDIS_COMMANDS = ["demat", "mat", "flight", "cloister", "quickdemat", "quickmat", ]
+#Fetch list of sounds to be played
+sounds = os.listdir("sounds")
 
 def selectSound(command):
-    """Takes string command and checks if it is in `TARDIS_COMMANDS`, returning the path to the `.mp3` file if True
+    """Takes string command and checks if it is in `sounds`, returning the path to the `.mp3` file if True
     """
-    if command not in TARDIS_COMMANDS:
-        return False
-    return "sounds/%s.mp3" % command
+    sound = "{}.mp3".format(command)
+    if sound not in sounds:
+        return None
+    return "sounds/{}".format(sound)
 
-def playSound(sound):
+def playSound(sound, playLight=True):
+    global decoder
     """Play the given sound and run the lamp 
     :param sound: the path to the audio file to be played
     """
-    if audio.playing:
-        return None
-    else:
-        audio.play(MP3Decoder(sound))
-        asyncio.run(light())
-        return True
+    with audiobusio.I2SOut(board.GP10, board.GP11, board.GP9) as audio:#BCLK_PIN, WS_PIN, SDIN_PIN
+        if audio.playing:
+            return False
+        else:
+            decoder.file = open(sound, "rb")
+            audio.play(decoder)
+            while audio.playing:
+                if playLight:
+                    asyncio.run(light())
+            return True
 
 async def light():
     """
     PWM pulse LED for duration of audio file currently playing
     """
+    global first_run
     max = 255
     min = 0
-    with pwmio.PWMOut(board.GP17) as pwm:
-        while audio.playing:
-            for i in chain(range(min, max, 1), range(max, min, -1)):
-                pwm.duty_cycle = i*i
-                await asyncio.sleep(0.004)
+    if first_run:
+        await asyncio.sleep(3)  
+        for i in range(min, max, 1):
+            lamp.duty_cycle=i*i
+            await asyncio.sleep(0.003)
+        first_run = False
+    for i in chain(range(max, min, -1), range(min, max, 1)):
+        lamp.duty_cycle = i*i
+        await asyncio.sleep(0.003)
 
 @server.route("/command")
 def handleTardisCommand(request):
     """
     Ingests a parameter from the HTTP request, asks for the file path to the relevant sound and tells the 
     TARDIS to run the sound
-    :param request: the HTTPRequest coming from the client. This should contain a paramater called `a` containing
+    :param request: the HTTPRequest coming from the client. This should contain a paramater called `sound` and `light` containing
     a command for the TARDIS to execute
     """
-    command = request.query_params.get("a")
+    sound = request.query_params.get("sound")
+    light = request.query_params.get("light")
     response = HTTPResponse(request)
-    sound = selectSound(command)
-    if sound:
+    if light is not bool:
+        light = False
+    sound = selectSound(sound)
+    if sound is not None:
         body = "OK"
-        response.status=HTTPStatus(200, "OK")
-        if playSound(sound) is None:
-            body = "Sound already playing, please wait"
-            response.status=HTTPStatus(503, "Busy")
+        response.status=HTTPStatus(200, "Playing {}. Light flashing: {}".format(sound, light))
+        response.send(body)
+        playSound(sound, light)
+        if light:
+            pass
+        # The below If statement is currently pointless because CircuitPython cannot properly work asynchronously on a Pico, so the check is irrelevant
+        # if not playSound(sound):
+        #     body = "Sound already playing, please wait"
+        #     response.status=HTTPStatus(503, "Busy")
     else:
         body = "Invalid parameter"
         response.status=HTTPStatus(400, "Bad Request")
-    response.send(body)
+        response.send(body)
 
 async def connectToWiFi():  
     wifi.radio.hostname="TARDIS"
@@ -83,15 +104,22 @@ async def startHTTPServer():
         microcontroller.reset()
     
 async def loop():
+    global first_run
+    first_run=True
+    if first_run:
+        pass
+        # playSound(selectSound("startup"))
     while True:
         server.poll()
 
 async def main():
+    global decoder
     wifi = asyncio.create_task(connectToWiFi())
     startServer = asyncio.create_task(startHTTPServer())
     asyncio.gather(wifi, startServer)
+    decoder = MP3Decoder(open("/sounds/startup.mp3", "rb")) #Opening a MP3Decoder takes up a lot of memory, so we do it here to save the precious KBs during runtime
 
-    asyncio.run(loop())
+    asyncio.run(loop()) #Run server.poll() on a permanent loop until we crash, switch off or are interrupted
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
- Moved GPIO variables to global level so that they are initialised before startup
- Changed the method of determining commands, now we assume that all items in the "sounds" folder are eligible for playing, and it is up to the user to decide how they want to play them
- Added option for pulsing light into web request parameters, if left blank it assumes True
- Now initialising the MP3Decoder in main() because it's memory intensive and can clog up the little memory we have to play with
- Added a first run that initialises the TARDIS with a nice startup sound upon switching on
- Changed progression of the web request handler so that the response is sent _before_ the light and sound is activated